### PR TITLE
fix: disable fail-fast on validate-bun-executable-pr matrix jobs

### DIFF
--- a/.github/workflows/validate-bun-executable-pr.yml
+++ b/.github/workflows/validate-bun-executable-pr.yml
@@ -15,6 +15,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macOS-latest, windows-latest, ubuntu-latest]
     steps:
@@ -23,6 +24,7 @@ jobs:
   test-executable:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macOS-latest, windows-latest, ubuntu-latest]
     steps:


### PR DESCRIPTION
## Summary
- Adds `fail-fast: false` to the `test` and `test-executable` matrix strategies in `validate-bun-executable-pr.yml`.

## Context
While investigating a Windows-only spawn bug in `example-cli`, we hit a real workflow problem twice: an unrelated intermittent network flake in the `ubuntu-latest` functional test scenario failed first and cancelled the `windows-latest` job before it could run, so we couldn't get signal on whether the Windows fix actually worked. With `fail-fast: false`, each OS in the matrix reports its own result independently.

Note: this repo's consumers pin to `@v1`, which currently trails `master` (`v1` is at `df42012`, `master` at `a6528a0` at the time of this PR). Once this merges to `master`, `v1` will still need to be moved forward (however that's normally done in this repo) for downstream repos to actually pick up the change.

## Test plan
- [x] Validated YAML syntax with `python3 -c "import yaml; yaml.safe_load(...)"`

https://claude.ai/code/session_01BHouCzjk6bFtxnHDPmiocC